### PR TITLE
Fix CI pipeline and upgrade to current ESPHome/Ceedling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Ruby",
-	"image": "mcr.microsoft.com/devcontainers/ruby:3.0@sha256:84ec41f29cabe46f80f235427e64ad675927eda08c50ce54429c6dd661ef9d23",
+	"image": "mcr.microsoft.com/devcontainers/ruby:4.0@sha256:a3b6bd7d706c5a162ad87ef1ffdb495c250f45d9633020561b6308b78bd54261",
 	"postCreateCommand": "bundle install && pip install -r requirements.txt",
 	"features": {
 	"ghcr.io/devcontainers/features/python:1": {},

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,23 +18,29 @@ jobs:
       - semver
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
       - uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5
         with:
           path: |
             .esphome
+            ~/.esphome
+            ~/.platformio
           key: ${{ runner.os }}-${{ hashFiles('src/*') }}-${{ hashFiles('childrensclock.yaml') }}
-      - uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3
-        with:
-          runCmd: rake test
-      - uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3
-        with:
-          runCmd: rake build
-          env: |
-            VERSION=${{ needs.semver.outputs.semantic_version}}
+      - run: pip install -r requirements.txt
+      - run: bundle exec rake test
+      - run: bundle exec rake build
+        env:
+          VERSION: ${{ needs.semver.outputs.semantic_version }}
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: firmware-factory.bin
-          path: .esphome/build/childrensclock/.pioenvs/childrensclock/firmware.factory.bin
+          path: .esphome/build/childrensclock/build/firmware.factory.bin
 
   semver:
     name: Generate a semantic version number

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - semver
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "3.3"
           bundler-cache: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'ceedling', '0.31.1'
+gem 'ceedling', '1.1.2'
 gem 'rake', '13.3.1'
 gem 'guard', '2.19.0'
 gem 'guard-rake', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ceedling (0.31.1)
+    benchmark (0.5.0)
+    ceedling (1.1.2)
+      benchmark (>= 0.3)
       constructor (~> 2)
       deep_merge (~> 1.2)
+      diy (~> 1.1)
+      erb (>= 2.2)
+      parallel (~> 1.26)
       rake (>= 12, < 14)
-      thor (~> 0.14)
+      thor (~> 1.3)
+      unicode-display_width (~> 3.1)
     coderay (1.1.3)
     constructor (2.0.0)
     deep_merge (1.2.2)
+    diy (1.1.2)
+      constructor (>= 1.0.0)
+    erb (6.0.6)
     ffi (1.17.0)
     formatador (1.1.0)
     guard (2.19.0)
@@ -32,6 +41,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    parallel (1.28.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -40,15 +50,19 @@ GEM
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     shellany (0.0.1)
-    thor (0.20.3)
+    thor (1.5.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   aarch64-linux
   arm64-darwin-22
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
-  ceedling (= 0.31.1)
+  ceedling (= 1.1.2)
   guard (= 2.19.0)
   guard-rake (= 1.0.0)
   rake (= 13.3.1)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+# ponytail: this repo's only C code is header-only (see src/childrensclock.h,
+# included straight into ESPHome's build and unit-tested via Ceedling), so
+# there's no top-level build system for CodeQL's C/C++ autobuilder to find.
+# Give it one trivial target so it can actually extract and scan the code.
+all:
+	$(CC) -x c -c src/childrensclock.h -o /dev/null

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 desc "Run all tests with Ceedling"
 task :test do
-  sh "bundle exec ceedling clobber test:all gcov:all utils:gcov"
+  sh "bundle exec ceedling clobber test:all gcov:all"
 end
 
 desc "Build/Compile with esphome"

--- a/childrensclock.yaml
+++ b/childrensclock.yaml
@@ -4,7 +4,7 @@ wifi:
     ssid: "Clock Fallback Hotspot"
 
 esp32_improv:
-  authorizer: false
+  authorizer: none
 
 improv_serial:
   next_url: http://{{ip_address}}
@@ -15,14 +15,11 @@ api:
   reboot_timeout: 0s
 
 web_server:
-  ota: true
   log: off
   version: 2
 
 esphome:
   name: childrensclock
-  platform: ESP32
-  board: esp32dev
   name_add_mac_suffix: true
   includes:
     - src/childrensclock.h
@@ -37,6 +34,11 @@ esphome:
     priority: 700
     then:
       - light.turn_off: led_matrix_light
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
 
 dashboard_import:
   package_import_url: github://chrisns/childrens-clock/childrensclock.yaml
@@ -56,6 +58,7 @@ ota:
     on_begin:
       then:
         - light.turn_off: led_matrix_light
+  - platform: web_server
 
 logger:
   level: DEBUG
@@ -142,6 +145,12 @@ sensor:
         TimeAsDecimal(id(weekend_bedtime).hour, id(weekend_bedtime).minute)
       );
 
+globals:
+  - id: applied_tz
+    type: std::string
+    restore_value: false
+    initial_value: '""'
+
 time:
   - platform: sntp
     id: sntp_time
@@ -158,23 +167,23 @@ time:
             then:
               - light.turn_on: led_matrix_light
         - lambda: |
-            auto current = id(sntp_time).get_timezone().c_str();
-            auto desired = id(tz).state.c_str();
-            if (id(sntp_time).now().is_valid() && strcmp(current,desired) != 0) {
-              ESP_LOGI("TIME", "Timezone doesn't match desired current %s, desired %s", current, desired);
+            auto desired = id(tz).state;
+            if (id(sntp_time).now().is_valid() && id(applied_tz) != desired) {
+              ESP_LOGI("TIME", "Timezone doesn't match desired current %s, desired %s", id(applied_tz).c_str(), desired.c_str());
               id(sntp_time).set_timezone(desired);
               id(sntp_time).call_setup();
+              id(applied_tz) = desired;
             }
     on_time:
       - seconds: 5
         then:
           lambda: |
-            auto current = id(sntp_time).get_timezone().c_str();
-            auto desired = id(tz).state.c_str();
-            if (id(sntp_time).now().is_valid() && strcmp(current,desired) != 0) {
-              ESP_LOGI("TIME", "Timezone doesn't match desired current %s, desired %s", current, desired);
+            auto desired = id(tz).state;
+            if (id(sntp_time).now().is_valid() && id(applied_tz) != desired) {
+              ESP_LOGI("TIME", "Timezone doesn't match desired current %s, desired %s", id(applied_tz).c_str(), desired.c_str());
               id(sntp_time).set_timezone(desired);
               id(sntp_time).call_setup();
+              id(applied_tz) = desired;
             }
 
 font:

--- a/project.yml
+++ b/project.yml
@@ -7,7 +7,7 @@
 
 :project:
   :use_exceptions: FALSE
-  :use_test_preprocessor: TRUE
+  :use_test_preprocessor: :none
   :use_auxiliary_dependencies: TRUE
   :build_root: build
   # :release_build: TRUE
@@ -25,6 +25,8 @@
   :test:
     - +:test/**
   :source:
+    - src/**
+  :include:
     - src/**
 
 :defines:
@@ -53,10 +55,9 @@
     - m
 
 :plugins:
-  :load_paths:
-    - "#{Ceedling.load_path}"
+  :load_paths: []
   :enabled:
-    - stdout_pretty_tests_report
+    - report_tests_pretty_stdout
     - module_generator
     - gcov
 :gcov:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-esphome==2024.10.3
-pillow==10.2.0
+esphome==2026.7.3
+pillow==12.3.0
 gcovr==8.5

--- a/src/childrensclock.h
+++ b/src/childrensclock.h
@@ -2,11 +2,11 @@
 #include <stdbool.h>
 
 
-float TimeAsDecimal(float hour, float minute) {
+static float TimeAsDecimal(float hour, float minute) {
   return hour + (0.0166666666667 * minute);
 }
 
-float CalculateProgress(float currentHour, float startHour, float endHour) {
+static float CalculateProgress(float currentHour, float startHour, float endHour) {
   float progress = 0.0;
   float totalHours;
 
@@ -38,14 +38,14 @@ float CalculateProgress(float currentHour, float startHour, float endHour) {
 }
 
 
-int ProgressToDots(float progressPercent, int totalDots) {
+static int ProgressToDots(float progressPercent, int totalDots) {
   // Calculate the number of unlit dots using ceil for rounding up any fractional part
   int unlitDots = (int) ceil((progressPercent / 100.0) * totalDots);
   // Calculate the number of lit dots by subtracting unlit dots from total
   return unlitDots < totalDots ? totalDots - unlitDots : 0;
 }
 
-bool IsWeekday(int dayOfWeek) {
+static bool IsWeekday(int dayOfWeek) {
   if (dayOfWeek == 1 || dayOfWeek == 7) {
     return false;
   }
@@ -54,19 +54,19 @@ bool IsWeekday(int dayOfWeek) {
   }
 }
 
-const int GREEN = 0;
-const int AMBER = 1;
-const int RED = 2;
+static const int GREEN = 0;
+static const int AMBER = 1;
+static const int RED = 2;
 
-const int SUN = 1;
-const int MON = 2;
-const int TUE = 3;
-const int WED = 4;
-const int THU = 5;
-const int FRI = 6;
-const int SAT = 7;
+static const int SUN = 1;
+static const int MON = 2;
+static const int TUE = 3;
+static const int WED = 4;
+static const int THU = 5;
+static const int FRI = 6;
+static const int SAT = 7;
 
-int GetState(int dayOfWeek, float currentTime, float weekday_go, float weekday_wake, float weekday_bedtime, float weekend_go, float weekend_wake, float weekend_bedtime) {
+static int GetState(int dayOfWeek, float currentTime, float weekday_go, float weekday_wake, float weekday_bedtime, float weekend_go, float weekend_wake, float weekend_bedtime) {
   // Determine current day type: weekday or weekend
   int isWeekend = (dayOfWeek == SAT || dayOfWeek == SUN);
   int isWeekendNight = (dayOfWeek == FRI || dayOfWeek == SAT);


### PR DESCRIPTION
## Summary
- CI has been red on every push/PR: the `devcontainers/ci` build of `mcr.microsoft.com/devcontainers/ruby:3.0` fails outright (stale yarn apt key on its bullseye base breaks `apt-get` for any feature install, e.g. `#291`, `#293`, all the renovate digest PRs). Replaced with direct `ruby/setup-ruby` + `actions/setup-python` steps on `ubuntu-latest` — no Docker layer, no devcontainer fragility.
- Fixed the firmware artifact upload path, which was still pointing at PlatformIO's old `.pioenvs/` layout; current ESPHome uses `build/firmware.factory.bin`. This is also almost certainly why #138 ("missing firmware in releases") has been happening — `release-binaries` couldn't find the artifact.
- Upgraded `esphome` 2024.10.3 → 2026.7.3 and fixed the resulting breaking config changes in `childrensclock.yaml`: `esphome.platform` moved to its own `esp32:` block, `esp32_improv.authorizer` no longer accepts a bool, `web_server`'s `ota` option was replaced by an `ota:` platform entry, and `RealTimeClock` lost `get_timezone()` (now tracked via a small `applied_tz` global instead).
- Upgraded `ceedling` 0.31.1 → 1.1.2 (0.31.1's `bin/ceedling` calls the long-removed `File.exists?`, so it can't run under any Ruby recent enough for CI) and fixed `project.yml` for the 1.x schema changes.
- Gave `childrensclock.h`'s functions/globals `static` linkage — they were being pulled into both the test file and Ceedling's generated runner as external symbols, causing duplicate-symbol link errors on the unit tests. This bug pre-dates this PR but was never caught because CI has been broken.
- Bumped `pillow` 10.2.0 → 12.3.0 for the outstanding security advisory (supersedes #292/#293).

## Test plan
- [x] `esphome compile childrensclock.yaml` succeeds locally against 2026.7.3, producing `firmware.factory.bin`
- [x] `bundle exec rake test` passes locally (5/5 Ceedling unit tests, gcov coverage report generated)
- [x] `bundle exec rake build` passes locally end-to-end via the same Rakefile CI invokes
- [ ] CI green on this PR

https://claude.ai/code/session_01816trnQFQBrvugHpdPPudV