### PR TITLE
Fix progress-percent calculation across midnight/weekend boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You will need to buy:
 - 1x [ESP32](https://www.aliexpress.com/item/1005006692499859.html) £1.91 _(worth buying a few in case you mess up the soldering)_
 - 1x [WS2812B 8x32 LED Matrix](https://www.aliexpress.com/item/1005002399031444.html) £2.59
 - 1x [15x5" Photo frame](https://www.amazon.co.uk/dp/B0BBPJPFC9)
+- 1x 5V power supply rated for **at least 4-5A** — 256 WS2812 LEDs can draw well beyond what a typical 1-2A USB charger or phone brick supplies, even at modest brightness. Undersized supplies cause brownout resets rather than an obvious failure, which is a confusing thing to debug.
 
 You will need:
 

--- a/childrensclock.yaml
+++ b/childrensclock.yaml
@@ -84,26 +84,16 @@ sensor:
     icon: mdi:percent
     update_interval: 5s
     lambda: |
-      float now = id(current_time_decimal).state;
-      int day_of_week = id(sntp_time).now().day_of_week;
-      float percent;
-      int currentstate = id(current_state).state;
-      // TODO: improve logic so progress is calculated right on friday and sunday nights
-
-      if (day_of_week == SAT || day_of_week == SUN) {
-        if (currentstate == AMBER) {
-          percent = CalculateProgress(now, TimeAsDecimal(id(weekend_bedtime).hour, id(weekend_bedtime).minute), TimeAsDecimal(id(weekend_go).hour, id(weekend_go).minute));
-        } else {
-          percent = CalculateProgress(now, TimeAsDecimal(id(weekend_bedtime).hour, id(weekend_bedtime).minute), TimeAsDecimal(id(weekend_wake).hour, id(weekend_wake).minute));
-        }
-      } else {
-        if (currentstate == AMBER) {
-          percent = CalculateProgress(now, TimeAsDecimal(id(weekday_wake).hour, id(weekday_wake).minute), TimeAsDecimal(id(weekday_go).hour, id(weekday_go).minute));
-        } else {
-          percent = CalculateProgress(now, TimeAsDecimal(id(weekday_bedtime).hour, id(weekday_bedtime).minute), TimeAsDecimal(id(weekday_wake).hour, id(weekday_wake).minute));
-        }
-      }
-      return percent;
+      return GetProgress(
+        id(sntp_time).now().day_of_week,
+        id(current_time_decimal).state,
+        TimeAsDecimal(id(weekday_go).hour, id(weekday_go).minute),
+        TimeAsDecimal(id(weekday_wake).hour, id(weekday_wake).minute),
+        TimeAsDecimal(id(weekday_bedtime).hour, id(weekday_bedtime).minute),
+        TimeAsDecimal(id(weekend_go).hour, id(weekend_go).minute),
+        TimeAsDecimal(id(weekend_wake).hour, id(weekend_wake).minute),
+        TimeAsDecimal(id(weekend_bedtime).hour, id(weekend_bedtime).minute)
+      );
 
   - name: Current time as decimal
     disabled_by_default: true
@@ -286,6 +276,7 @@ display:
     addressable_light_id: led_matrix_light
     width: 32
     height: 8
+    update_interval: 1s
     rotation: 0°
     pixel_mapper: |-
       if (x % 2 == 0) {
@@ -309,9 +300,12 @@ display:
             break;
         }
 
-        int line_length = id(dots).state;
+        int line_length = std::min(int(id(dots).state), 31);
         auto time_text = id(current_time).state;
-        
+        if (time_text.empty()) {
+          return;
+        }
+
         it.line(0, 0, line_length, 0, color);
 
 

--- a/src/childrensclock.h
+++ b/src/childrensclock.h
@@ -68,7 +68,7 @@ static const int SAT = 7;
 
 static int GetState(int dayOfWeek, float currentTime, float weekday_go, float weekday_wake, float weekday_bedtime, float weekend_go, float weekend_wake, float weekend_bedtime) {
   // Determine current day type: weekday or weekend
-  int isWeekend = (dayOfWeek == SAT || dayOfWeek == SUN);
+  int isWeekend = !IsWeekday(dayOfWeek);
   int isWeekendNight = (dayOfWeek == FRI || dayOfWeek == SAT);
 
   // Determine time thresholds based on the day type
@@ -83,5 +83,41 @@ static int GetState(int dayOfWeek, float currentTime, float weekday_go, float we
     return GREEN;  // Active period
   } else {
     return RED;    // Resting period
+  }
+}
+
+static float GetProgress(int dayOfWeek, float currentTime, float weekday_go, float weekday_wake, float weekday_bedtime, float weekend_go, float weekend_wake, float weekend_bedtime) {
+  int currentstate = GetState(dayOfWeek, currentTime, weekday_go, weekday_wake, weekday_bedtime, weekend_go, weekend_wake, weekend_bedtime);
+
+  if (currentstate == AMBER) {
+    int isWeekend = !IsWeekday(dayOfWeek);
+    float wakeTime = isWeekend ? weekend_wake : weekday_wake;
+    float goTime = isWeekend ? weekend_go : weekday_go;
+    return CalculateProgress(currentTime, wakeTime, goTime);
+  } else {
+    // We are in the RED state. This can be before wake (morning) or after bed (evening).
+    int isWeekend = !IsWeekday(dayOfWeek);
+    float wakeTime = isWeekend ? weekend_wake : weekday_wake;
+    int isWeekendNight = (dayOfWeek == FRI || dayOfWeek == SAT);
+    float bedtime = isWeekendNight ? weekend_bedtime : weekday_bedtime;
+
+    float startBedtime;
+    float endWaketime;
+
+    if (currentTime < wakeTime) {
+      // It's morning. We woke up from yesterday's bedtime.
+      int yesterday = (dayOfWeek == SUN) ? SAT : (dayOfWeek - 1);
+      int isYesterdayWeekendNight = (yesterday == FRI || yesterday == SAT);
+      startBedtime = isYesterdayWeekendNight ? weekend_bedtime : weekday_bedtime;
+      endWaketime = wakeTime; // Today's wake time
+    } else {
+      // It's evening. We will wake up to tomorrow's wake time.
+      int tomorrow = (dayOfWeek == SAT) ? SUN : (dayOfWeek + 1);
+      int isTomorrowWeekend = !IsWeekday(tomorrow);
+      startBedtime = bedtime; // Today's bedtime
+      endWaketime = isTomorrowWeekend ? weekend_wake : weekday_wake;
+    }
+
+    return CalculateProgress(currentTime, startBedtime, endWaketime);
   }
 }

--- a/test/TestMain.c
+++ b/test/TestMain.c
@@ -112,6 +112,38 @@ void testGetState(void) {
 }
 
 
+void testGetProgress(void) {
+  float weekday_go = 8;
+  float weekday_wake = 7;
+  float weekday_bedtime = 18;
+
+  float weekend_go = 9;
+  float weekend_wake = 8;
+  float weekend_bedtime = 19;
+
+  // Monday 3am (bedtime 18, wake 7 -> total 13h, 18 to 3 is 9h. 9/13 = ~69%)
+  TEST_ASSERT_FLOAT_WITHIN(1.0, 69.2, GetProgress(MON, 3, weekday_go, weekday_wake, weekday_bedtime, weekend_go, weekend_wake, weekend_bedtime));
+
+  // Friday 6pm (GREEN, 100% since out of bounds for amber/red)
+  TEST_ASSERT_EQUAL_FLOAT(100.0, GetProgress(FRI, 18, weekday_go, weekday_wake, weekday_bedtime, weekend_go, weekend_wake, weekend_bedtime));
+
+  // Saturday 7:30am (RED, bedtime 19, wake 8 -> total 13h, 19 to 7.5 is 12.5h. 12.5/13 = ~96%)
+  TEST_ASSERT_FLOAT_WITHIN(1.0, 96.1, GetProgress(SAT, 7.5, weekday_go, weekday_wake, weekday_bedtime, weekend_go, weekend_wake, weekend_bedtime));
+
+  // Saturday 8:30am (AMBER, wake 8, go 9 -> total 1h, 8 to 8.5 is 0.5h. 0.5/1 = 50%)
+  TEST_ASSERT_EQUAL_FLOAT(50.0, GetProgress(SAT, 8.5, weekday_go, weekday_wake, weekday_bedtime, weekend_go, weekend_wake, weekend_bedtime));
+
+  // Friday 3:00am (RED, yesterday Thursday, so startBedtime is weekday_bedtime 18. wake is weekday_wake 7. Total 13h. 18 to 3 is 9h. 9/13 = ~69%)
+  TEST_ASSERT_FLOAT_WITHIN(1.0, 69.2, GetProgress(FRI, 3.0, weekday_go, weekday_wake, weekday_bedtime, weekend_go, weekend_wake, weekend_bedtime));
+
+  // Sunday 8:00pm (RED, evening. today Sunday, tomorrow Monday. so endWaketime is weekday_wake 7. bedtime is weekday_bedtime 18. Total 13h. 18 to 20 is 2h. 2/13 = ~15%)
+  TEST_ASSERT_FLOAT_WITHIN(1.0, 15.3, GetProgress(SUN, 20.0, weekday_go, weekday_wake, weekday_bedtime, weekend_go, weekend_wake, weekend_bedtime));
+
+  // Sunday 3:00am (RED, yesterday Saturday, so startBedtime is weekend_bedtime 19. wake is weekend_wake 8. Total 13h. 19 to 3 is 8h. 8/13 = ~61%)
+  TEST_ASSERT_FLOAT_WITHIN(1.0, 61.5, GetProgress(SUN, 3.0, weekday_go, weekday_wake, weekday_bedtime, weekend_go, weekend_wake, weekend_bedtime));
+}
+
+
 // void testGetColor(void) {
   // TEST_ASSERT_EQUAL_STRING("GREEN", GetColor(50, 64));
 


### PR DESCRIPTION
## Summary
Distilled from the useful parts of #291, which bundles a genuine bug fix in with a fork rebrand, a yaml rename, and an LED-driver/framework migration that aren't needed.

- Fixes the long-standing `// TODO: improve logic so progress is calculated right on friday and sunday nights` in the `progress_percent` sensor. The old hand-rolled logic picked bedtime/wake thresholds based on whether *today* is Sat/Sun, which is wrong whenever the resting period actually spans a day-type change (Friday night → Saturday morning, Sunday night → Monday morning).
- Adds `GetProgress()` in `src/childrensclock.h`, which reuses `GetState()` and looks at yesterday's/tomorrow's day-type when the resting period straddles midnight — matching the `isWeekendNight` handling `GetState()` already does for bedtime. Wired into the sensor lambda in place of the old duplicate branching.
- Adds `testGetProgress` covering the boundary cases (Friday 3am, Sunday 8pm, Sunday 3am, etc.) — note: #291 added this same function and test but never actually called `GetProgress()` from the sensor, so the bug it was meant to fix was still live there.
- `GetState()` now reuses `IsWeekday()` instead of duplicating the day check.
- Display lambda: skip drawing before `current_time` is valid, and clamp the dot-line length to the display width.
- `display.update_interval: 1s`, matching how often the underlying sensors actually update (was defaulting to ~16ms).
- README: added a PSU sizing note (256 WS2812 LEDs need a real 5V 4-5A supply, not a phone charger — undersized supplies brownout rather than failing obviously).

Left out of this PR (see #291 discussion): the fork-branding README changes, the `childrensclock.yaml` → `childrens-clock.yaml` rename (breaks `dashboard_import` for existing users), the `neopixelbus` → `esp32_rmt_led_strip`/`esp-idf` migration (unnecessary — neopixelbus still compiles fine on current ESPHome), the hardcoded `project.version` (would break semver-driven releases), and the substitutions-based multi-clock config (a real feature worth its own PR, changes the default wiring pin).

## Test plan
- [x] `bundle exec rake test` — 6/6 passing, including the new `testGetProgress` boundary cases
- [x] `esphome compile childrensclock.yaml` succeeds against 2026.7.3
- [ ] CI green on this PR

https://claude.ai/code/session_01816trnQFQBrvugHpdPPudV